### PR TITLE
Workaround updated package shipped

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV num_threads 2
 ENV uhd_branch maint
 ENV gr_branch maint
 
-RUN apt-get update && apt-get dist-upgrade -yf && apt-get clean && apt-get autoremove
+RUN apt-get update && apt-get dist-upgrade -yf --force-confnew & apt-get clean && apt-get autoremove
 RUN apt-get install -y \
         build-essential \
         cmake \


### PR DESCRIPTION
Sovle workaround for:
==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.